### PR TITLE
Sample timing profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ This is a small tool designed to allow you understand the per-request memory usa
 
 ## TODO:
 * Unit tests
-* Write up guide to all fields
 * Add CONTRIBUTING.md
 * Add Code of conduct file
 * Make sure post install script works as expected
@@ -108,40 +107,62 @@ export default { hello };
 Where in the above example, the third argument is random metadata.
 
 ## Interpreting the data
+In the report, we diverge from the Javascript convention of camelCase to be consistent with the output of the `njs.memoryStats` object.
+
+
 See the annotated example of output below:
 ```json
 {
-  "requestId":"d47b0035b0c47b7370118af2e1fba49c",
-  "begin":{
-    "size":47600,
-    "nblocks":3,
-    "cluster_size":32768,
-    "page_size":512
+  "request_id": "f005408d17a3b420132bb554c19a2066",
+  // These values are static and depend on your system
+  "cluster_size": 32768,
+  "page_size": 512,
+  "begin": {
+    // all timestamps are milliseconds since January 1, 1970 00:00:00 UTC.
+    "req_start_ms": 1669241329831,
+    // memory usage in bytes at the beginning of the request
+    "size": 47600,
+    // Number of memory blocks from the system allocated by njs
+    "nblocks": 3
   },
-  "end":{
-    "size":47600,
-    "nblocks":3,
-    "cluster_size":32768,
-    "page_size":512
+  "end": {
+    "req_end_ms": 1669241331834,
+    "size": 48216,
+    "nblocks": 4
   },
-  "growth":{
-    "size_growth":0,
-    "nblocks_growth":0,
-    "cluster_size_growth":0,
-    "page_size_growth":0
+  "growth": {
+    // memory growth over the course of the request in bytes
+    "size_growth": 616,
+    // number of additional memory block allocated over the course of the request
+    "nblocks_growth": 1
   },
-  "events":[{
-    event: "file_read",
-    rawStats: {
-      "size":47600,
-      "nblocks":3,
-      "cluster_size":32768,
-      "page_size":512
+  "elapsed_time_ms": 2003,
+  "events": [
+    {
+      "event": "before_wait",
+      // arbitrary keys and values can be passed to `meta`
+      // created_at_ms is created by the library
+      "meta": {
+        "foo": "bar",
+        "created_at_ms": 1669241329831
+      },
+      "raw_stats": {
+        "size": 47600,
+        "nblocks": 3
+      }
     },
-    meta: {
-      // Arbitrary keys and values
+    {
+      "event": "after_wait",
+      "meta": {
+        "foo": "bar",
+        "created_at_ms": 1669241331833
+      },
+      "raw_stats": {
+        "size": 56408,
+        "nblocks": 5
+      }
     }
-  }]
+  ]
 }
 ```
 ## Profiling overhead


### PR DESCRIPTION
# What
This is a very naive implementation of adding timings to the measurements.  In reality timing should be part of a different API in order to keep things pure, but the goal here is to just provide some of that information.

## Caveats
* It does not take subrequests into account
* In the future, I'd like to break this out so that the timing portion is optional so that users doing profile can include the absolute minimum in profiling code.
* Timing between events is not calculated to save work in the vm destroy hook