### PR TITLE
[DO NOT MERGE] [WIP] temporary solution to non js_content profiling

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -80,10 +80,23 @@ function nonStaticMemoryStats(rawStats) {
   };
 }
 
+function pushEventSync(event, meta, r) {
+  meta = meta || {};
+  meta.created_at_ms = Date.now();
+  const payload = {
+    request_id: r.variables.request_id,
+    event,
+    meta,
+    raw_stats: nonStaticMemoryStats(njs.memoryStats),
+  };
+
+  r.error(`{"type": "profiler:event", "payload": ${JSON.stringify(payload)} }`);
+}
+
 function logReporter(report, r) {
-  r.error("======== BEGIN MEMORY REPORT ==========");
-  r.error(JSON.stringify(report));
-  r.error("========  END MEMORY REPORT  ==========");
+  r.error(
+    `{"type": "profiler:summary", "payload": ${JSON.stringify(report)} }`
+  );
 }
 
 function fileReporter(report) {
@@ -99,4 +112,4 @@ function diff(initial, point) {
   };
 }
 
-export default { init, logReporter, fileReporter };
+export default { init, logReporter, fileReporter, pushEventSync };

--- a/index.mjs
+++ b/index.mjs
@@ -70,6 +70,7 @@ function init(r, reporterFn) {
   return {
     getReport,
     pushEvent,
+    requestId
   };
 }
 
@@ -80,11 +81,11 @@ function nonStaticMemoryStats(rawStats) {
   };
 }
 
-function pushEventSync(event, meta, r) {
+function pushEventSync(event, meta, r, request_id) {
   meta = meta || {};
   meta.created_at_ms = Date.now();
   const payload = {
-    request_id: r.variables.request_id,
+    request_id,
     event,
     meta,
     raw_stats: nonStaticMemoryStats(njs.memoryStats),

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.mjs",
   "scripts": {
     "test": "echo \"Prerelease code: tests pending\" && exit 0",
-    "postinstall": "node scripts/postinstall.js"
+    "postinstall": "node scripts/postinstall.js",
+    "log2json": "node scripts/logs-to-json.js"
   },
   "engines": {
     "node": ">=16"

--- a/scripts/logs-to-json.js
+++ b/scripts/logs-to-json.js
@@ -1,0 +1,34 @@
+const fs = require("node:fs");
+const readline = require("node:readline");
+const REGEX = /.+js\:\s(\{.+\})/;
+const src = process.argv[2];
+const dest = process.argv[3];
+
+if (!src || !dest) {
+  console.error("usage: npm run log2json src.log dest.log");
+  process.exit(1);
+}
+
+const rl = readline.createInterface({
+  input: fs.createReadStream(src),
+  crlfDelay: Infinity,
+});
+const ws = fs.createWriteStream(dest);
+ws.write("[");
+let lines = 0;
+rl.on("line", (line) => {
+  const match = line.match(REGEX);
+  if (match) {
+    if (lines === 0) {
+      ws.write(`${match[1]}`);
+    } else {
+      ws.write(`, ${match[1]}`);
+    }
+    lines = lines + 1;
+  }
+});
+
+rl.on("close", () => {
+  ws.write("]");
+  ws.end();
+});


### PR DESCRIPTION
### Proposed changes
We hit an issue where the profiler doesn't work well with workflows that are not just `js_content`.  If the workflow is split up between `js_set` and the like, we don't have a way of persisting data between event handlers.

This is a quick and dirty solution that does two things:

1. Provides a new method `pushEventSync` that just spits out the event to the logs immediately like so:
```
    {
    "type": "profiler:event",
    "payload": {
      "request_id": "c38254aa6509a46562c3a2a18c247391",
      "event": "js_var",
      "meta": {
        "function": "varfunc1",
        "action": "standalone",
        "created_at_ms": 1669864455551
      },
      "raw_stats": {
        "size": 47600,
        "nblocks": 3
      }
    }
  }
 ```

3. In the logs, the summary is now purely a json object that looks like this:
```
   {
    "type": "profiler:summary",
    "payload": {
      "request_id": "0c955b7d228d04b35fca4c22512967dc",
      "cluster_size": 32768,
      "page_size": 512,
      "begin": {
        "req_start_ms": 1669864455551,
        "size": 47600,
        "nblocks": 3
      },
      "end": {
        "req_end_ms": 1669864455551,
        "size": 47600,
        "nblocks": 3
      },
      "growth": {
        "size_growth": 0,
        "nblocks_growth": 0
      },
      "elapsed_time_ms": 0,
      "events": []
    }
  }
 ```

5. Provides a new cli command `log2json` that will filter down the json emitted to the logs into an array of objects of `type` `profiler:event` or `profiler:summary` both having a `payload` key.  Just run: 
    `log2json /tmp/dev.log filtered.json`

Then you'll get a json file like this:
```
[
  {
    "type": "profiler:event",
    "payload": {
      "request_id": "1ba8d5f6dce0a703709c767ab313679b",
      "event": "main_func",
      "meta": {
        "foo": "bar",
        "created_at_ms": 1669867887450
      },
      "raw_stats": {
        "size": 47600,
        "nblocks": 3
      }
    }
  },
  {
    "type": "profiler:event",
    "payload": {
      "request_id": "1ba8d5f6dce0a703709c767ab313679b",
      "event": "js_var",
      "meta": {
        "function": "varfunc1",
        "action": "standalone",
        "created_at_ms": 1669867887450
      },
      "raw_stats": {
        "size": 47600,
        "nblocks": 3
      }
    }
  },
  {
    "type": "profiler:summary",
    "payload": {
      "request_id": "1ba8d5f6dce0a703709c767ab313679b",
      "cluster_size": 32768,
      "page_size": 512,
      "begin": {
        "req_start_ms": 1669867887450,
        "size": 47600,
        "nblocks": 3
      },
      "end": {
        "req_end_ms": 1669867887451,
        "size": 47600,
        "nblocks": 3
      },
      "growth": {
        "size_growth": 0,
        "nblocks_growth": 0
      },
      "elapsed_time_ms": 1,
      "events": []
    }
  }
]

```

## Sample setup
Usage of this setup requires some extra steps which are:
* Init using `js_set` of the profiler to "start the clock"
* Creation of a `js_var` to hold the request id
* Usage of `pushEventSync` passing in the request id from `js_var`

The complications around the request id come from an issue I was having in test where `r.variables.request_id` was giving different values.  I plan to submit this as a bug to the njs project once I make sure it's not user error on my part.

`nginx.conf`
```nginx

worker_processes  1;

load_module modules/ngx_http_js_module.so;
error_log /tmp/dev.log debug;

events {
    worker_connections  1024;
}

http {
    js_import script from script.mjs;
    include       mime.types;
    default_type  application/json;

    # This stores the request id from the init of the profiler
    # For some reason it's changing if I just reference it in njs code
    js_var $static_request_id;
    
    # A refernce to this var inits the profiler to produce the summary
    # and populate `$static_request_id`
    js_set $request_id_profiler script.initProfiler;

    server {
       listen       4000;

       location / {
        js_set $my_var script.varfunc1;
        js_content script.main;
       }
    }
}
```

`script.mjs`
```javascript
// you'll need to change this for your setup
import profiler from "./node_modules/njs-memory-profiler/index.mjs";

function main(r) {
  // This is important because referencing this inits the profiler.
  // We need to make sure this variable is only referenced once and at the very beginning of the request
  // Multiple references are leading to multiple request ids being generated for some reason.
  r.error(`Init: ${r.variables.request_id_profiler}`);

  profiler.pushEventSync(
    "main_func",
    { foo: "bar" },
    r,
    r.variables.static_request_id
  );

  r.return(200, `Hello World: ${r.variables.my_var}`);
}

function initProfiler(r) {
  const p = profiler.init(r);
  // To avoid more invocations, we bind the request id to a variable defined with `js_var`
  r.variables.static_request_id = p.requestId;
  return p.requestId;
}

function varfunc1(r) {
  profiler.pushEventSync(
    "js_var",
    { function: "varfunc1", action: "standalone" },
    r,
    r.variables.static_request_id
  );
  return "valuevarfunc1";
}

export default { main, varfunc1, initProfiler };

```
### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [ ] I have formatted the code using prettier (`npx prettier -w .`)
- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests (when possible) that prove my fix is effective or that my feature works
- [ ] I have checked that all tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto `main`

