### PR TITLE
Remove custom install dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,11 @@ This library can be installed using the normal npm workflow:
 npm install njs-memory-profiler
 ```
 
-This module will install to a folder called `njs_modules` in the root of your project. If you want to use a different directory, run the install with the `NJS_MODULES_DIR` environment variable specified:
+This module will install to a folder called `njs_modules` in the root of your project.
 
-```bash
-NJS_MODULES_DIR=./ npm install njs-memory-profiler
-```
+Note: As the installation will be performed by an npm postinstall script. NodeJS version 16 or greater is required.
 
-Note: As the installation will be performed by a post-install JavaScript using `node` the minimal required version of Node will be 16 or greater.
-
-We recommend to use [nvm](https://github.com/nvm-sh/nvm) or [asdf](https://asdf-vm.com/) to manage your node versions.
+We recommend using [asdf](https://asdf-vm.com/) or [nvm](https://github.com/nvm-sh/nvm) to manage your node versions.
 
 If using `nvm`, just run `nvm install` from the root of the project.
 If using `asdf`, just run `asdf install` from the root of the project.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "njs-memory-profiler",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Simple memory profiling tool written for the NGINX Javascript Module (njs)",
   "main": "src/index.mjs",
   "scripts": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,15 +1,11 @@
 const fs = require("fs/promises");
-console.log(`njs-memory-profiler install script excuting from ${__dirname}`);
 const path = require("path");
 const package = require("../package.json");
 
 // This is the user's local directory
 const projectRoot = process.env.INIT_CWD || "./";
 
-// We'll assume that `njs_modules` is where all modules will go but let the user
-// override if desired
-const moduleBase =
-  process.env["NJS_MODULES_DIR"] || path.resolve(projectRoot, "./njs_modules");
+const moduleBase = path.resolve(projectRoot, "./njs_modules");
 
 // Each module should be in its own folder in case it has multiple files
 const libraryDirname = "njs-memory-profiler";


### PR DESCRIPTION
### Proposed changes

Previously you could specify where the njs modules would go.

Getting the installation to go to a custom directory was difficult
to test and one of those features no one asked for.

It can be added back in a more elegant way later if this is an
actual pain point the community has.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [ ] I have formatted the code using prettier (`npx prettier -w .`)
- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests (when possible) that prove my fix is effective or that my feature works
- [ ] I have checked that all tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto `main`
